### PR TITLE
fix z-index so that completion tooltips appear above the scratchpad

### DIFF
--- a/scratchpad.css
+++ b/scratchpad.css
@@ -6,7 +6,7 @@
   background-color: #F8F5E1;
   border-left: 1px solid #aaa;
   border-top: 1px solid #aaa;
-  z-index: 9000;
+  z-index: 105;
 }
 
 #nbextension-scratchpad .cell-wrapper {
@@ -19,7 +19,7 @@
   padding-right: 24px;
   opacity: 0.2;
   font-size: 24px;
-  z-index: 9001;
+  z-index: 106;
 }
 
 .scratchpad-btn:hover {


### PR DESCRIPTION
This has come up in #5, and also in https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/916, and should (hopefully) place the scratchpad above `div#pager`, which has z-index 100, but still below `.completions`, which has z-index 110. As a secondary benefit, it also keeps the scratchpad below any modals.