### PR TITLE
Fix to stop the scratchpad interfering with the scrollbar in firefox.

### DIFF
--- a/scratchpad.css
+++ b/scratchpad.css
@@ -16,7 +16,7 @@
 
 .scratchpad-btn {
   float: right;
-  padding-right: 24px;
+  margin-right: 24px;
   opacity: 0.2;
   font-size: 24px;
   z-index: 106;


### PR DESCRIPTION
Closes issue [#1004 from jupyter_contrib_nbextensions](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/1004). This pull-request was made at the suggestion of @jcb91.