### PR TITLE
Add shortcuts to line-wise execution

### DIFF
--- a/main.js
+++ b/main.js
@@ -124,7 +124,7 @@ define(function (require, exports, module) {
   };
 
   Scratchpad.prototype.copy_current_line = function(evt) {
-    if (this.collapsed) {
+    if (!utils.is_focused(this.element)) {
       var current_cell = this.notebook.get_selected_cell();
       var cm = current_cell.code_mirror;
       var selection = cm.getSelection();
@@ -135,12 +135,12 @@ define(function (require, exports, module) {
         current_value = cm.getLine(cm.getCursor().line);
       }
       this.cell.code_mirror.setValue(current_value);
-      this.toggle();
+      this.expand();
     }
   }
 
   Scratchpad.prototype.execute_current_line = function(evt) {
-    if (this.collapsed) {
+    if (!utils.is_focused(this.element)) {
       this.copy_current_line(evt);
       this.cell.execute();
     }

--- a/main.js
+++ b/main.js
@@ -51,10 +51,20 @@ define(function (require, exports, module) {
     var toggle_action = this.km.actions.register({
       handler: $.proxy(this.toggle, this),
     }, 'scratchpad-toggle');
-    
+    var execute_line_action = this.km.actions.register({
+      handler: $.proxy(this.execute_current_line, this),
+
+    }, 'scratchpad-execute-current-line');
+    var copy_line_action = this.km.actions.register({
+      handler: $.proxy(this.copy_current_line, this),
+
+    }, 'scratchpad-copy-current-line');
+
     var shortcuts = {
       'shift-enter': execute_and_select_action,
       'ctrl-enter': execute_action,
+      'ctrl-shift-enter': execute_line_action,
+      'ctrl-shift-alt-enter': copy_line_action,
       'ctrl-b': toggle_action,
     }
     this.km.edit_shortcuts.add_shortcuts(shortcuts);
@@ -112,6 +122,23 @@ define(function (require, exports, module) {
       this.notebook.execute_selected_cells();
     }
   };
+
+  Scratchpad.prototype.copy_current_line = function(evt) {
+    if (this.collapsed) {
+      var current_cell = this.notebook.get_selected_cell();
+      var cm = current_cell.code_mirror;
+      var current_line = cm.getLine(cm.getCursor().line);
+      this.cell.code_mirror.setValue(current_line);
+      this.toggle();
+    }
+  }
+
+  Scratchpad.prototype.execute_current_line = function(evt) {
+    if (this.collapsed) {
+      this.copy_current_line(evt);
+      this.cell.execute();
+    }
+  }
 
   function setup_scratchpad () {
     // lazy, hook it up to Jupyter.notebook as the handle on all the singletons

--- a/main.js
+++ b/main.js
@@ -129,13 +129,49 @@ define(function (require, exports, module) {
       var cm = current_cell.code_mirror;
       var selection = cm.getSelection();
       var current_value;
-      if (selection.length !== 0) {
-        current_value = selection;
-      } else {
-        current_value = cm.getLine(cm.getCursor().line);
+
+      // set the scratch cell's value and open the pad
+      var set_value = (function(value) {
+        this.cell.code_mirror.setValue(value.trim());
+        this.expand();
+      }).bind(this);
+
+      // try to find the targeted expression.
+      // send current line to the kernel, if it's incomplete,
+      // add the previous line and repeat
+      // if the checked buffer is complete, set the scratch cell's value
+      var find_expression = function(kernel, start_line, finish_line) {
+        if (start_line < 0) {
+          // something went wrong (most likely no expression in the cell)
+          // just return
+          console.error('No expression found in cell');
+          return;
+        }
+        var potential_expression = '';
+        for (var line_number=start_line; line_number <= finish_line; ++line_number) {
+          potential_expression += cm.getLine(line_number) + '\n';
+        }
+        potential_expression = potential_expression.trim();
+        var check_if_complete = function(msg) {
+          var status = msg.content.status;
+          if (status === 'complete') {
+            set_value(potential_expression);
+          } else {
+            find_expression(kernel, start_line - 1, finish_line);
+          }
+        }
+        kernel.send_shell_message('is_complete_request',
+                                            // replace newline with spaces for the completeness checker
+                                            { code: potential_expression.split('\n').join(' ') },
+                                            { shell: { reply: check_if_complete } });
       }
-      this.cell.code_mirror.setValue(current_value);
-      this.expand();
+
+      if (selection.length !== 0) {
+        set_value(selection);
+      } else {
+        var current_line = cm.getCursor().line;
+        find_expression(this.cell.kernel, current_line, current_line);
+      }
     }
   }
 

--- a/main.js
+++ b/main.js
@@ -127,8 +127,14 @@ define(function (require, exports, module) {
     if (this.collapsed) {
       var current_cell = this.notebook.get_selected_cell();
       var cm = current_cell.code_mirror;
-      var current_line = cm.getLine(cm.getCursor().line);
-      this.cell.code_mirror.setValue(current_line);
+      var selection = cm.getSelection();
+      var current_value;
+      if (selection.length !== 0) {
+        current_value = selection;
+      } else {
+        current_value = cm.getLine(cm.getCursor().line);
+      }
+      this.cell.code_mirror.setValue(current_value);
       this.toggle();
     }
   }


### PR DESCRIPTION
Hi,

I find myself often wishing to (re-)execute a single line or expression of a nb cell. This small change adds two shortcuts which allow exactly that:

Ctrl-Shift-Enter: executes current line (or currently selected lines) in the scratchpad immediately
Ctrl-Shift-Alt-Enter: copies current line (or currently selected lines) into the scratchpad

If you like this idea and are willing to merge such a change, I can extend the docs, too.

Cheers!