### PR TITLE
Change shortcut "ctrl-b" to "cmd-b"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Adds a scratchpad cell to Jupyter notebook.
 This is a cell in which you can execute code against the current kernel without modifying the notebook document.
 
 The scratchpad can be toggled by clicking the icon in the bottom-right,
-or via the keyboard shortcut `Ctrl-B`.
+or via the keyboard shortcut `Cmd-B`.
 
 ![demo](demo.gif)
 

--- a/main.js
+++ b/main.js
@@ -50,7 +50,7 @@ define([
     cell.refresh();
     this.collapse();
 
-    // override ctrl/shift-enter to execute me if I'm focused instead of the notebook's cell
+    // override cmd/shift-enter to execute me if I'm focused instead of the notebook's cell
     var execute_and_select_action = this.km.actions.register({
       handler: $.proxy(this.execute_and_select_event, this),
     }, 'scratchpad-execute-and-select');
@@ -64,7 +64,7 @@ define([
     var shortcuts = {
       'shift-enter': execute_and_select_action,
       'ctrl-enter': execute_action,
-      'ctrl-b': toggle_action,
+      'cmd-b': toggle_action,
     }
     this.km.edit_shortcuts.add_shortcuts(shortcuts);
     this.km.command_shortcuts.add_shortcuts(shortcuts);


### PR DESCRIPTION
For Mac/Linux users, using "ctrl-b" may cause conflict with native keybindings for cursor moving. Thanks.