### PR TITLE
Workaround for bug when interacting with jupyter-vim-binding

### DIFF
--- a/main.js
+++ b/main.js
@@ -66,8 +66,15 @@ define([
       'ctrl-enter': execute_action,
       'ctrl-b': toggle_action,
     }
-    this.km.edit_shortcuts.add_shortcuts(shortcuts);
-    this.km.command_shortcuts.add_shortcuts(shortcuts);
+
+    // Workaround for a bug when using this extension together with jupyter-vim-binding.
+    // Whenever this extension loads before jupyter-vim-binding, the shortcuts get overwritten
+    // causing this extension to break. Therefore, wait 2 seconds to force jupyter-vim-binding
+    // to finish loading before we register our shortcuts.
+    setTimeout(function(){
+      scratchpad.km.edit_shortcuts.add_shortcuts(shortcuts);
+      scratchpad.km.command_shortcuts.add_shortcuts(shortcuts);
+    }, 2000);
 
     // finally, add me to the page
     $("body").append(this.element);


### PR DESCRIPTION
This PR is a workaround for issue #7, where this extension sometimes breaks if jupyter-vim-binding is installed at the same time.

It seems that whenever this extension loads before jupyter-vim-binding, the shortcuts get overwritten causing this extension to break. The loading order of the extensions is nondeterminstic, so the bug only appears some of the time. I don't know enough about Jupyter internals to figure out a proper fix, but for now, a good workaround is to wait 2 seconds to force jupyter-vim-binding to finish loading before we register our shortcuts.